### PR TITLE
Update run

### DIFF
--- a/run
+++ b/run
@@ -12,4 +12,4 @@ echo "$@" > .command
     init=$(pwd)/linux-init \
     WORKDIR=$(pwd) HOME=$HOME
 
-exit $(cat .exit_code)
+return $(cat .exit_code)


### PR DESCRIPTION
It should be return for correct handling when `.exit_code` does not exists.
