### PR TITLE
Upgrade Docker (Fixes #6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ install:
 - sh -xe install.sh
 
 script:
+- ./run "docker version && docker info"
 - ./run docker run ubuntu /bin/echo hello world
 - wget https://gist.githubusercontent.com/moul/0f53ae391ae7d7116e24/raw/23307093546b6ae2f94208c188f5ce4fca2be996/docker-compose.yml
 - ./run docker-compose build test

--- a/install.sh
+++ b/install.sh
@@ -2,29 +2,32 @@
 
 set -xe
 
+
 # Disable post-install autorun
 echo exit 101 | sudo tee /usr/sbin/policy-rc.d
 sudo chmod +x /usr/sbin/policy-rc.d
+
 
 # Install dependencies
 sudo apt-get update
 sudo apt-get install -y slirp lxc aufs-tools cgroup-lite
 
-# Install docker 1.4.1 (see https://github.com/moul/travis-docker/issues/4)
-# sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
-# sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
-sudo mkdir -p /var/lib/docker
-wget https://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.4.1/lxc-docker-1.4.1_1.4.1_amd64.deb && \
-  sudo dpkg -i lxc-docker-1.4.1_1.4.1_amd64.deb && \
-  rm -f lxc-docker-1.4.1_1.4.1_amd64.deb
+
+# Install docker
+curl -s https://get.docker.com/ | sh
+sudo usermod -aG docker $USER
+sudo chown -R travis /etc/docker
+
 
 # Install fig
 sudo curl -L https://github.com/docker/fig/releases/download/1.0.1/fig-`uname -s`-`uname -m` -o /usr/local/bin/fig
 sudo chmod +x /usr/local/bin/fig
 
+
 # Install docker-compose
 sudo curl -L https://github.com/docker/compose/releases/download/1.1.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
+
 
 # Download binary
 curl -sLo linux https://github.com/jpetazzo/sekexe/raw/master/uml

--- a/linux-init
+++ b/linux-init
@@ -59,6 +59,7 @@ mount -t tmpfs none /var/lib/docker
 # enable ipv4 forwarding for docker
 echo 1 > /proc/sys/net/ipv4/ip_forward
 
+
 # configure networking
 ip addr add 127.0.0.1 dev lo
 ip link set lo up
@@ -66,14 +67,22 @@ ip addr add 10.1.1.1/24 dev eth0
 ip link set eth0 up
 ip route add default via 10.1.1.254
 
+
 # configure dns (google public)
 mkdir -p /run/resolvconf
 echo 'nameserver 8.8.8.8' > /run/resolvconf/resolv.conf
 mount --bind /run/resolvconf/resolv.conf /etc/resolv.conf
 
+
 # Start docker daemon
 docker -d &
 sleep 5
+
+
+# Print docker version
+docker info
+docker version
+
 
 # Call command
 command=$(cat ${WORKDIR}/.command)

--- a/linux-init
+++ b/linux-init
@@ -76,7 +76,7 @@ mount --bind /run/resolvconf/resolv.conf /etc/resolv.conf
 
 # Start docker daemon
 docker -d &
-sleep 5
+while ! [ -e /var/run/docker.sock ]; do sleep 0.1; done
 
 
 # Print docker version

--- a/linux-init
+++ b/linux-init
@@ -17,6 +17,7 @@ save_and_shutdown() {
 
     # save built for host result
     # force clean shutdown
+    set +e
     echo KILLING
     kill -9 $(jobs -p)
     halt -f


### PR DESCRIPTION
https://travis-ci.org/moul/travis-docker/builds/58901773

```
$ docker version
Client version: 1.6.0
Client API version: 1.18
Go version (client): go1.4.2
Git commit (client): 4749651
OS/Arch (client): linux/amd64
Server version: 1.6.0
Server API version: 1.18
Go version (server): go1.4.2
Git commit (server): 4749651
OS/Arch (server): linux/amd64
```

```
$ docker info
Containers: 0
Images: 0
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Backing Filesystem: tmpfs
 Dirs: 0
 Dirperm1 Supported: false
Execution Driver: native-0.2
Kernel Version: 3.8.13.4
Operating System: <unknown>
CPUs: 1
Total Memory: 1.923 GiB
Name: (none)
```
