### PR TITLE
Reset caller's environment and workingdir, ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 linux
 .command
 .exit_code
+.envp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: true
+
 install:
 - sh -xe install.sh
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Inspired by [lukecyca/travis-docker-example](https://github.com/lukecyca/travis-
 ## *.travis.yml* examples
 
 ```yaml
+sudo: true
+
 install:
 - curl -sLo - http://j.mp/install-travis-docker | sh -xe
 

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ sudo apt-get install -y slirp lxc aufs-tools cgroup-lite
 # Install docker
 curl -s https://get.docker.com/ | sh
 sudo usermod -aG docker $USER
-sudo chown -R travis /etc/docker
+sudo chown -R $USER /etc/docker
 
 
 # Install fig

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,8 @@ set -xe
 COMPOSE_VERSION=1.2.0
 
 
+cd "$(dirname "$0")"
+
 # Disable post-install autorun
 echo exit 101 | sudo tee /usr/sbin/policy-rc.d
 sudo chmod +x /usr/sbin/policy-rc.d

--- a/install.sh
+++ b/install.sh
@@ -25,13 +25,17 @@ sudo chown -R $USER /etc/docker
 
 
 # Install fig
-sudo curl -L https://github.com/docker/fig/releases/download/1.0.1/fig-`uname -s`-`uname -m` -o /usr/local/bin/fig
-sudo chmod +x /usr/local/bin/fig
+if [ "x$UML_FIG" != x0 ]; then
+    sudo curl -L https://github.com/docker/fig/releases/download/1.0.1/fig-`uname -s`-`uname -m` -o /usr/local/bin/fig
+    sudo chmod +x /usr/local/bin/fig
+fi
 
 
 # Install docker-compose
-sudo curl -L https://github.com/docker/compose/releases/download/$COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+if [ "x$UML_DOCKERCOMPOSE" != x0 ] ; then
+    sudo curl -L https://github.com/docker/compose/releases/download/$COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+fi
 
 
 # Download binary

--- a/linux-init
+++ b/linux-init
@@ -7,12 +7,12 @@ set -e
 # echo "Env: $(env)"
 # echo "Cmdline: $(cat /proc/cmdline)"
 
-rm -f ${WORKDIR}/.exit_code
+rm -f "${UMLDIR}/.exit_code"
 
 save_and_shutdown() {
     # Default exit code
-    if [ ! -f ${WORKDIR}/.exit_code ]; then
-	echo 42 > ${WORKDIR}/.exit_code
+    if [ ! -f "${UMLDIR}/.exit_code" ]; then
+        echo 42 > "${UMLDIR}/.exit_code"
     fi
 
     # save built for host result
@@ -27,7 +27,7 @@ save_and_shutdown() {
 trap save_and_shutdown EXIT SIGINT SIGTERM
 
 # go back to where we were invoked
-cd $WORKDIR
+cd "${WORKDIR}"
 
 # configure path to include /usr/local
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -85,7 +85,7 @@ docker version
 
 
 # Call command
-command=$(cat ${WORKDIR}/.command)
+command=$(cat "${UMLDIR}/.command")
 set +e
 /bin/bash -ce "${command}"
-echo $? > ${WORKDIR}/.exit_code
+echo $? > "${UMLDIR}/.exit_code"

--- a/linux-init
+++ b/linux-init
@@ -83,6 +83,8 @@ while ! [ -e /var/run/docker.sock ]; do sleep 0.1; done
 docker info
 docker version
 
+# reset environment
+. "${UMLDIR}/.envp"
 
 # Call command
 command=$(cat "${UMLDIR}/.command")

--- a/run
+++ b/run
@@ -5,6 +5,7 @@ WORKDIR="$(pwd)"
 cd "$(dirname "$0")"
 UMLDIR="$(pwd)"
 echo "$@" > "${UMLDIR}/.command"
+export -p > "${UMLDIR}/.envp"
 rm -f "${UMLDIR}/.exit_code"
 
 (

--- a/run
+++ b/run
@@ -10,7 +10,7 @@ rm -f "${UMLDIR}/.exit_code"
 
 (
     set -x
-    "${UMLDIR}/linux" \
+    sudo "${UMLDIR}/linux" \
 	quiet \
 	mem=2G \
 	rootfstype=hostfs rw \

--- a/run
+++ b/run
@@ -1,20 +1,22 @@
 #!/bin/sh
 
 set -e
-WORKDIR=$(pwd)
-echo "$@" > .command
-rm -f .exit_code
+WORKDIR="$(pwd)"
+cd "$(dirname "$0")"
+UMLDIR="$(pwd)"
+echo "$@" > "${UMLDIR}/.command"
+rm -f "${UMLDIR}/.exit_code"
 
 (
     set -x
-    ./linux \
+    "${UMLDIR}/linux" \
 	quiet \
 	mem=2G \
 	rootfstype=hostfs rw \
 	eth0=slirp,,/usr/bin/slirp-fullbolt \
-	init=${WORKDIR}/linux-init \
-	WORKDIR=${WORKDIR} HOME=${HOME}
+	"init=${UMLDIR}/linux-init" \
+	"WORKDIR=${WORKDIR}" "UMLDIR=${UMLDIR}"
 )
 
-exit_code=$(cat .exit_code)
+exit_code=$(cat "${UMLDIR}/.exit_code")
 eval exit ${exit_code}


### PR DESCRIPTION
These are the changes I extracted from ViDA-NYU/reprozip#115

I did not include the move to `.travis/uml-docker/`, the change where I use the files from the current repo rather than curl'ing the scripts, and disabling fig and docker-compose (although it is doable via env vars).

The problem of course is that because scripts get curl'ed, the tests ran for this branch don't actually reflect the passing status (they are downloaded from your master branch).
